### PR TITLE
Prevent the project header images from stretching vertically

### DIFF
--- a/src/app/components/ProjectInfo.js
+++ b/src/app/components/ProjectInfo.js
@@ -31,14 +31,14 @@ const projects = {
     title: '',
     render: () => (
       <>
-        <img src={ptvMobileApp} width="75%"></img>
+        <img src={ptvMobileApp} width="75%" style={{objectFit: 'contain'}}></img>
       </>
     )
   },
   'harmony-project': {
     title: '',
     render: () => (
-      <img src={hpMobileApp} width="75%"></img>
+      <img src={hpMobileApp} width="75%" style={{objectFit: 'contain'}}></img>
     )
   },
   'farm2people': {


### PR DESCRIPTION
The project header images for PTV and Harmony Project were stretching on Chrome mobile. Added "object-fit: contain" to keep the aspect ratio the same. 
![image](https://user-images.githubusercontent.com/20175954/133876872-f659af08-149c-4189-a7d1-473eadeb80ef.png)
![image](https://user-images.githubusercontent.com/20175954/133876937-b486dcf9-d0c3-4d28-9f88-a4348d939979.png)
