### PR TITLE
Changed node-sass dependency to sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "emailjs-com": "^2.6.4",
     "gh-pages": "^2.2.0",
     "history": "^4.10.1",
-    "node-sass": "^4.14.1",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
     "react-bootstrap": "^1.4.3",
@@ -54,6 +53,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^1.7.0",
+    "sass": "^1.63.6",
     "stylelint": "^13.9.0",
     "stylelint-config-standard": "^19.0.0"
   }


### PR DESCRIPTION
Module [node-sass](https://www.npmjs.com/package/node-sass) has been deprecated, leading to errors when attempting to run `npm install --save` for development purposes. The solution (found [here](https://bobbyhadz.com/blog/node-sass-command-failed-when-running-npm-install)), was to switch to [sass](https://www.npmjs.com/package/sass).